### PR TITLE
17 improve test coverage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rato.data
 Title: Fetch data from the RATO database
-Version: 0.1.1
+Version: 0.1.1.9000
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rato.data
 Title: Fetch data from the RATO database
-Version: 0.1.0.9000
+Version: 0.1.1
 Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6658-6062")),

--- a/R/get_objects.R
+++ b/R/get_objects.R
@@ -52,6 +52,7 @@ get_objects <- function(object_ids, token = get_token()) {
   objects_response %>%
     purrr::chuck("features") %>%
     purrr::map(~ purrr::pluck(.x, "attributes")) %>%
+    # Convert every record in a single row data.frame, replace NULL with NA
     purrr::map(~ as.data.frame(
       purrr::map(
         .x,
@@ -60,6 +61,7 @@ get_objects <- function(object_ids, token = get_token()) {
         }
       )
     )) %>%
+    # Combine all the data.frames together so we have one row per record
     purrr::list_rbind() %>%
     return()
 }

--- a/R/get_objects.R
+++ b/R/get_objects.R
@@ -13,7 +13,7 @@ get_objects <- function(object_ids, token = get_token()) {
   object_id_query <- glue::glue(
     "OBJECTID IN ({object_ids_collated})",
     object_ids_collated = glue::glue_collapse(object_ids,
-                                              sep = ","
+      sep = ","
     )
   ) %>%
     curl::curl_escape()
@@ -21,11 +21,13 @@ get_objects <- function(object_ids, token = get_token()) {
   # Build request for the API
   objects_request <-
     httr2::request("https://gis.oost-vlaanderen.be/server/rest/services/") %>%
-    httr2::req_url_path_append("RATO2",
-                               "RATO2_Dossiers_Publiek",
-                               "MapServer",
-                               "0",
-                               glue::glue("query?where={object_id_query}")) %>%
+    httr2::req_url_path_append(
+      "RATO2",
+      "RATO2_Dossiers_Publiek",
+      "MapServer",
+      "0",
+      glue::glue("query?where={object_id_query}")
+    ) %>%
     httr2::req_url_query(
       outFields = "*",
       f = "json",
@@ -50,6 +52,14 @@ get_objects <- function(object_ids, token = get_token()) {
   objects_response %>%
     purrr::chuck("features") %>%
     purrr::map(~ purrr::pluck(.x, "attributes")) %>%
-    purrr::map_dfr(~.x) %>%
+    purrr::map(~ as.data.frame(
+      purrr::map(
+        .x,
+        \(field_value) {
+          ifelse(is.null(field_value), NA, field_value)
+        }
+      )
+    )) %>%
+    purrr::list_rbind() %>%
     return()
 }

--- a/tests/testthat/test-get_objects.R
+++ b/tests/testthat/test-get_objects.R
@@ -1,0 +1,15 @@
+test_that("get_objects() can retreive a single object", {
+  # Need to be able to connect to API
+  skip_if_offline(host = "gis.oost-vlaanderen.be")
+  # Need to have credentials stored
+  skip_if(Sys.getenv("RATO_USER") == "")
+  skip_if(Sys.getenv("RATO_PWD") == "")
+  
+  
+  expect_s3_class(
+    get_objects(list_object_ids()[1]),
+    "data.frame"
+  )
+  
+})
+

--- a/tests/testthat/test-get_objects.R
+++ b/tests/testthat/test-get_objects.R
@@ -13,3 +13,18 @@ test_that("get_objects() can retreive a single object", {
   
 })
 
+test_that("get_objects() returns one row for every input object_id", {
+  # Need to be able to connect to API
+  skip_if_offline(host = "gis.oost-vlaanderen.be")
+  # Need to have credentials stored
+  skip_if(Sys.getenv("RATO_USER") == "")
+  skip_if(Sys.getenv("RATO_PWD") == "")
+  
+  # Store 25 random object ids for testing
+  object_ids <- sample(list_object_ids(), size = 25)
+  
+  expect_length(
+   get_objects(object_ids)[[1]], # compare length of values of first column
+   length(object_ids)
+  )
+})


### PR DESCRIPTION
Tests run slow because the calls to `list_object_ids()` and `get_objects()` are slow. `get_objects()` fails when more than 50 objects are requested.

This PR brought a hidden dependency to dplyr to light, as `purrr::map_dfr()` needs it, but it's not in `Depends` for `purrr`. Using superseded functions can be risky, but my workaround is much more difficult to read. 

I want to avoid loading dplyr, as I want to reduce the number of dependencies in the long run. 

## AI Summary
This pull request includes several improvements and additions to the `get_objects` function and its associated tests. The most important changes include refactoring the API request construction, enhancing the data transformation process, and adding new tests to ensure functionality.

Improvements to `get_objects` function:

* [`R/get_objects.R`](diffhunk://#diff-26f07980f3e431d39be072a9c6de661036b100ddc0d3197c24708925743679a7L24-R30): Refactored the API request construction by breaking down the `req_url_path_append` call for better readability and maintainability.
* [`R/get_objects.R`](diffhunk://#diff-26f07980f3e431d39be072a9c6de661036b100ddc0d3197c24708925743679a7L53-R65): Enhanced the data transformation process by converting each record into a single row `data.frame` and replacing `NULL` values with `NA`. This ensures a more robust handling of the data.

Additions to tests:

* [`tests/testthat/test-get_objects.R`](diffhunk://#diff-ead37af20b43fba8093c5b150e574ee20148bfbef40f304d4a184ef04f05c76cR1-R30): Added a test to verify that `get_objects` can retrieve a single object and return it as a `data.frame`.
* [`tests/testthat/test-get_objects.R`](diffhunk://#diff-ead37af20b43fba8093c5b150e574ee20148bfbef40f304d4a184ef04f05c76cR1-R30): Added a test to ensure that `get_objects` returns one row for every input `object_id`, verifying the consistency of the output.