### PR TITLE
Remove `Published through RIPARIAS` badge: repo is not a dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 <!-- badges: start -->
-[![funding](https://img.shields.io/static/v1?label=published+through&message=LIFE+RIPARIAS&labelColor=00a58d&color=ffffff)](https://www.riparias.be/)
 [![R-CMD-check](https://github.com/inbo/rato-data/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/inbo/rato-data/actions/workflows/R-CMD-check.yaml)
 [![Codecov test coverage](https://codecov.io/gh/inbo/rato-data/graph/badge.svg)](https://app.codecov.io/gh/inbo/rato-data)
 <!-- badges: end -->


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change removes the funding badge that is used on the rato occurrences repo to indicate that the dataset is published through LIFE RIPARIAS. Because this repo is not a dataset, it seems inappropriate to use the same badge here. We can add a new RIPARIAS badge later on if appropriate. 